### PR TITLE
Added new plugin for defining custom actions on pushes to a repository

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@
 * Remove support for ``post_pr_comment`` - instead we now support exclusively
   status checks. [#49]
 
+* Added support for custom actions on push. [#53]
+
 0.2 (2018-11-22)
 ----------------
 

--- a/baldrick/plugins/github_pushes.py
+++ b/baldrick/plugins/github_pushes.py
@@ -43,10 +43,6 @@ def handle_pushes(repo_handler, payload, headers):
     if not push_config.get("enabled", False):
         return "Skipping commit handlers, disabled in configuration file"
 
-    # Disable if the config is not present
-    if push_config is None:
-        return
-
     for function in PUSH_HANDLERS:
         function(repo_handler, git_ref)
 

--- a/baldrick/plugins/github_pushes.py
+++ b/baldrick/plugins/github_pushes.py
@@ -1,0 +1,53 @@
+from baldrick.github.github_api import RepoHandler
+from baldrick.blueprints.github import github_webhook_handler
+
+__all__ = ['push_handler']
+
+PUSH_HANDLERS = []
+
+
+def push_handler(func):
+    """
+    A decorator to add functions to the push handler.
+
+    Functions decorated with this decorator will be called for any push events
+    to the repository. They will be passed ``(repo_handler, git_ref)`` and no
+    return values are expected (all actions should happen inside the functions).
+    """
+    PUSH_HANDLERS.append(func)
+    return func
+
+
+@github_webhook_handler
+def handle_pushes(repo_handler, payload, headers):
+    """
+    Handle push events.
+    """
+
+    event = headers['X-GitHub-Event']
+
+    if event not in ('push'):
+        return "Not a push event"
+
+    # Get the ref for the push - could be e.g. a branch or a tag
+    git_ref = payload['ref']
+
+    # If we are on a branch, make a new repo handler with the correct branch
+    if git_ref.startswith('refs/heads/'):
+        branch = git_ref.replace('refs/heads/', '')
+        repo_handler = RepoHandler(repo_handler.repo, branch,
+                                   repo_handler.installation)
+
+    # Get configuration for this plugin
+    push_config = repo_handler.get_config_value("pushes", {})
+    if not push_config.get("enabled", False):
+        return "Skipping commit handlers, disabled in configuration file"
+
+    # Disable if the config is not present
+    if push_config is None:
+        return
+
+    for function in PUSH_HANDLERS:
+        function(repo_handler, git_ref)
+
+    return 'Finished handling push event'

--- a/baldrick/plugins/tests/test_github_pushes.py
+++ b/baldrick/plugins/tests/test_github_pushes.py
@@ -1,0 +1,84 @@
+import json
+from copy import copy
+from unittest.mock import MagicMock, patch
+
+from baldrick.github.github_api import cfg_cache
+from baldrick.plugins.github_pushes import push_handler, PUSH_HANDLERS
+
+test_handler = MagicMock()
+
+
+CONFIG_TEMPLATE = """
+[ tool.testbot ]
+[ tool.testbot.pushes ]
+enabled = true
+"""
+
+
+def setup_module(module):
+    module.PUSH_HANDLERS_ORIG = copy(PUSH_HANDLERS)
+    push_handler(test_handler)
+
+
+def teardown_module(module):
+    PUSH_HANDLERS[:] = module.PUSH_HANDLERS_ORIG[:]
+
+
+class TestPushHandler:
+
+    def setup_method(self, method):
+
+        test_handler.reset_mock()
+
+        self.get_file_contents_mock = patch('baldrick.github.github_api.GitHubHandler.get_file_contents')
+        self.get_installation_token_mock = patch('baldrick.github.github_auth.get_installation_token')
+
+        self.get_file_contents = self.get_file_contents_mock.start()
+        self.get_installation_token = self.get_installation_token_mock.start()
+
+        self.get_installation_token.return_value = 'abcdefg'
+
+        cfg_cache.clear()
+
+    def teardown_method(self, method):
+        self.get_file_contents_mock.stop()
+        self.get_installation_token_mock.stop()
+
+    def send_event(self, client, git_ref='refs/heads/master'):
+
+        data = {'ref': git_ref,
+                'repository': {'full_name': 'test-repo'},
+                'installation': {'id': '123'}}
+        headers = {'X-GitHub-Event': 'push'}
+
+        client.post('/github', data=json.dumps(data), headers=headers,
+                    content_type='application/json')
+
+    def test_branch(self, app, client):
+        self.get_file_contents.return_value = CONFIG_TEMPLATE
+        self.send_event(client, git_ref='refs/heads/experimental')
+        assert test_handler.call_count == 1
+        repo_handler, git_ref = test_handler.call_args[0]
+        assert repo_handler.repo == 'test-repo'
+        assert repo_handler.branch == 'experimental'
+        assert git_ref == 'refs/heads/experimental'
+
+    def test_tags(self, app, client):
+        self.get_file_contents.return_value = CONFIG_TEMPLATE
+        self.send_event(client, git_ref='refs/tags/stable')
+        assert test_handler.call_count == 1
+        repo_handler, git_ref = test_handler.call_args[0]
+        assert repo_handler.repo == 'test-repo'
+        assert repo_handler.branch == 'master'
+        assert git_ref == 'refs/tags/stable'
+
+    def test_disabled(self, app, client):
+        self.get_file_contents.return_value = CONFIG_TEMPLATE.replace('enabled = true',
+                                                                      'enabled = false')
+        self.send_event(client, git_ref='refs/tags/stable')
+        assert test_handler.call_count == 0
+
+    def test_missing_config(self, app, client):
+        self.get_file_contents.return_value = ""
+        self.send_event(client, git_ref='refs/tags/stable')
+        assert test_handler.call_count == 0

--- a/doc/app.rst
+++ b/doc/app.rst
@@ -20,6 +20,7 @@ plugins if you have developed any additional ones. The available plugins are::
     import baldrick.plugins.circleci_artifacts
     import baldrick.plugins.github_milestones
     import baldrick.plugins.github_pull_requests
+    import baldrick.plugins.github_pushes
     import baldrick.plugins.github_towncrier_changelog
 
 And finally use the following to start up the bot::

--- a/doc/plugins.rst
+++ b/doc/plugins.rst
@@ -28,6 +28,36 @@ set of artifacts, for example::
 The ``url`` item should be set to the file path of the artifacts, and the
 message is what will be shown in the status check.
 
+Push handlers
+-------------
+
+We provide a plugin that will perform custom actions whenever a push is made to
+a repository.
+
+To enable pull request handlers, include the following in your
+``pyproject.toml`` file::
+
+    [ tool.<your-bot-name>.pushes ]
+    enabled = true
+
+If you want to write your own custom handler, import
+``push_handler`` from baldrick as follows::
+
+    from baldrick.plugins.github_pushes import push_handler
+
+then use it to decorate a function of the form::
+
+    @push_handler
+    def do_something_on_push(repo_handler, git_ref):
+        ...
+
+This function will be called with ``repo_handler``, an instance of
+:class:`~baldrick.github.github_api.RepoHandler` (click on
+the class names to find out the available properties/methods), and ``git_ref``
+which will be a string containing the ref for the push (e.g.
+``refs/heads/master``). If the ``git_ref`` is a branch, ``repo_handler.branch``
+will be correctly set, but note that the ``git_ref`` could also point to a tag.
+
 Pull request handlers
 ---------------------
 

--- a/doc/plugins.rst
+++ b/doc/plugins.rst
@@ -32,7 +32,7 @@ Push handlers
 -------------
 
 We provide a plugin that will perform custom actions whenever a push is made to
-a repository.
+a repository, whether to a branch or a tag.
 
 To enable pull request handlers, include the following in your
 ``pyproject.toml`` file::

--- a/template/run.py
+++ b/template/run.py
@@ -9,6 +9,7 @@ app = create_app('<your-bot-name>')
 import baldrick.plugins.circleci_artifacts
 import baldrick.plugins.github_milestones
 import baldrick.plugins.github_pull_requests
+import baldrick.plugins.github_pushes
 import baldrick.plugins.github_towncrier_changelog
 
 # Bind to PORT if defined, otherwise default to 5000.


### PR DESCRIPTION
This seemed like it should be generically useful so thought it made sense to add here. My use case is making a custom action for astropy-bot that automatically adds new contributors to the astropy contributor team.