### PR TITLE
TST: Strict settings for pytest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,8 @@ ignore = E501,W504
 
 [tool:pytest]
 flake8-ignore = E501 W504
+filterwarnings = error
+xfail_strict = true
 
 [yapf]
 column_limit = 100


### PR DESCRIPTION
This turns all warnings and any `xpassed` into errors. Maybe this will help track down the mysterious #61 when it happens again...