### PR TITLE
ENH: Use check for PR instead of status

### DIFF
--- a/baldrick/github/github_api.py
+++ b/baldrick/github/github_api.py
@@ -62,7 +62,7 @@ class GitHubHandler:
     @property
     def _headers(self):
         if self.installation is None:
-            return None
+            return {}
         else:
             return github_request_headers(self.installation)
 
@@ -218,13 +218,15 @@ class GitHubHandler:
             The commit has to get the statuses for
         """
         url = f'{HOST}/repos/{self.repo}/commits/{commit_hash}/check-runs'
-        results = paged_github_json_request(url, headers=self._headers)
+        headers = self._headers
+        headers['Accept'] = 'application/vnd.github.antiope-preview+json'
+        results = paged_github_json_request(url, headers=headers)
 
         checks = {}
-        for result in results['check_runs']:
+        for result in results.get('check_runs', []):
             context = result['name']
             checks[context] = {'summary': result['output']['summary'],
-                               'details_url': result['details_url'],
+                               'details_url': result.get('details_url'),
                                'status': result['status'],
                                'conclusion': result['conclusion']}
 
@@ -581,6 +583,21 @@ class PullRequestHandler(IssueHandler):
         elif commit_hash == "base":
             commit_hash = self.base_sha
         return super().list_statuses(commit_hash)
+
+    def list_checks(self, commit_hash="head"):
+        """
+        List checks on a commit on GitHub.
+
+        Parameters
+        ----------
+        commit_hash : str, optional
+            The commit hash to set the check on. Defaults to "head" can also be "base".
+        """
+        if commit_hash == "head":
+            commit_hash = self.head_sha
+        elif commit_hash == "base":
+            commit_hash = self.base_sha
+        return super().list_checks(commit_hash)
 
     @property
     def _url_pull_request(self):

--- a/baldrick/github/github_api.py
+++ b/baldrick/github/github_api.py
@@ -208,6 +208,28 @@ class GitHubHandler:
 
         return statuses
 
+    def list_checks(self, commit_hash):
+        """
+        List check messages on a commit on GitHub.
+
+        Parameters
+        ----------
+        commit_hash : str
+            The commit has to get the statuses for
+        """
+        url = f'{HOST}/repos/{self.repo}/commits/{commit_hash}/check-runs'
+        results = paged_github_json_request(url, headers=self._headers)
+
+        checks = {}
+        for result in results['check_runs']:
+            context = result['name']
+            checks[context] = {'summary': result['output']['summary'],
+                               'details_url': result['details_url'],
+                               'status': result['status'],
+                               'conclusion': result['conclusion']}
+
+        return checks
+
 
 class RepoHandler(GitHubHandler):
 

--- a/baldrick/github/tests/test_github_api.py
+++ b/baldrick/github/tests/test_github_api.py
@@ -44,7 +44,7 @@ class TestRepoHandler:
     def test_urls(self):
         assert self.repo._url_contents == 'https://api.github.com/repos/fakerepo/doesnotexist/contents/'
         assert self.repo._url_pull_requests == 'https://api.github.com/repos/fakerepo/doesnotexist/pulls'
-        assert self.repo._headers is None
+        assert self.repo._headers == {}
 
 
 TEST_CONFIG = """

--- a/baldrick/plugins/github_pull_requests.py
+++ b/baldrick/plugins/github_pull_requests.py
@@ -148,12 +148,13 @@ def process_pull_request(repository, number, installation, action,
 
     # Post each failure as a status
 
-    existing_statuses = pr_handler.list_statuses()
+    existing_checks = pr_handler.list_checks()
 
     for context, details in sorted(results.items()):
 
         full_context = current_app.bot_username + ':' + context
 
+        # TODO: Revisit if the note made for statuses still applies to checks.
         # NOTE: we could in principle check if the status has been posted
         # before, and if so not post it again, but we had this in the past
         # and there were some strange caching issues where GitHub would
@@ -167,7 +168,7 @@ def process_pull_request(repository, number, installation, action,
     # For statuses that have been skipped this time but existed before, set
     # status to pass and set message to say skipped
 
-    for full_context in existing_statuses:
+    for full_context in existing_checks:
 
         if full_context.startswith(current_app.bot_username + ':'):
             context = full_context[len(current_app.bot_username) + 1:]
@@ -175,13 +176,13 @@ def process_pull_request(repository, number, installation, action,
                 pr_handler.set_check(
                     current_app.bot_username + ':' + context,
                     'This check has been skipped', status='completed',
-                    conclusion='success')
+                    conclusion='neutral')
 
         # Also set the general 'single' status check as a skipped check if it
         # is present
         if full_context == current_app.bot_username:
             pr_handler.set_check(
                 current_app.bot_username, 'This check has been skipped',
-                status='completed', conclusion='success')
+                status='completed', conclusion='neutral')
 
     return 'Finished pull requests checks'

--- a/baldrick/plugins/tests/test_github_pull_requests.py
+++ b/baldrick/plugins/tests/test_github_pull_requests.py
@@ -33,7 +33,7 @@ class TestPullRequestHandler:
         test_hook.resetmock()
 
         self.pr_comments = []
-        self.existing_statuses = []
+        self.existing_checks = {}
         self.pr_open = True
 
         self.requests_get_mock = patch('requests.get', self._requests_get)
@@ -72,8 +72,8 @@ class TestPullRequestHandler:
             return req
         elif url == 'https://api.github.com/repos/test-repo/issues/1234/comments':
             req.json.return_value = self.pr_comments
-        elif url == 'https://api.github.com/repos/test-repo/commits/abc464aa/statuses':
-            req.json.return_value = self.existing_statuses
+        elif url == 'https://api.github.com/repos/test-repo/commits/abc464aa/check-runs':
+            req.json.return_value = self.existing_checks
         else:
             raise ValueError('Unexepected URL: {0}'.format(url))
         return req
@@ -106,8 +106,9 @@ class TestPullRequestHandler:
 
         # As above, but a default message is given
 
-        test_hook.return_value = {'test1': {'description': 'No problem', 'state': 'success'},
-                                  'test2': {'description': 'All good here', 'state': 'success'}}
+        test_hook.return_value = {
+            'test1': {'description': 'No problem', 'state': 'success'},
+            'test2': {'description': 'All good here', 'state': 'success'}}
 
         self.get_file_contents.return_value = CONFIG_TEMPLATE
 
@@ -116,23 +117,32 @@ class TestPullRequestHandler:
         assert self.requests_post.call_count == 2
 
         args, kwargs = self.requests_post.call_args_list[0]
-        assert args[0] == 'https://api.github.com/repos/test-repo/statuses/abc464aa'
-        assert kwargs['json'] == {'state': 'success',
-                                  'description': 'No problem',
-                                  'context': 'testbot:test1'}
+        kwargs['json'].pop('completed_at')  # Actual value not important
+        assert args[0] == 'https://api.github.com/repos/test-repo/check-runs'
+        assert kwargs['json'] == {'name': 'testbot:test1',
+                                  'head_sha': 'abc464aa',
+                                  'status': 'completed',
+                                  'conclusion': 'success',
+                                  'output': {'title': 'testbot:test1',
+                                             'summary': 'No problem'}}
 
         args, kwargs = self.requests_post.call_args_list[1]
-        assert args[0] == 'https://api.github.com/repos/test-repo/statuses/abc464aa'
-        assert kwargs['json'] == {'state': 'success',
-                                  'description': 'All good here',
-                                  'context': 'testbot:test2'}
+        kwargs['json'].pop('completed_at')  # Actual value not important
+        assert args[0] == 'https://api.github.com/repos/test-repo/check-runs'
+        assert kwargs['json'] == {'name': 'testbot:test2',
+                                  'head_sha': 'abc464aa',
+                                  'status': 'completed',
+                                  'conclusion': 'success',
+                                  'output': {'title': 'testbot:test2',
+                                             'summary': 'All good here'}}
 
     def test_one_failure(self, app, client):
 
         # As above, but a default message is given
 
-        test_hook.return_value = {'test1': {'description': 'Problems here', 'state': 'failure'},
-                                  'test2': {'description': 'All good here', 'state': 'success'}}
+        test_hook.return_value = {
+            'test1': {'description': 'Problems here', 'state': 'failure'},
+            'test2': {'description': 'All good here', 'state': 'success'}}
 
         self.get_file_contents.return_value = CONFIG_TEMPLATE
 
@@ -141,78 +151,112 @@ class TestPullRequestHandler:
         assert self.requests_post.call_count == 2
 
         args, kwargs = self.requests_post.call_args_list[0]
-        assert args[0] == 'https://api.github.com/repos/test-repo/statuses/abc464aa'
-        assert kwargs['json'] == {'state': 'failure',
-                                  'description': 'Problems here',
-                                  'context': 'testbot:test1'}
+        kwargs['json'].pop('completed_at')  # Actual value not important
+        assert args[0] == 'https://api.github.com/repos/test-repo/check-runs'
+        assert kwargs['json'] == {'name': 'testbot:test1',
+                                  'head_sha': 'abc464aa',
+                                  'status': 'completed',
+                                  'conclusion': 'failure',
+                                  'output': {'title': 'testbot:test1',
+                                             'summary': 'Problems here'}}
 
         args, kwargs = self.requests_post.call_args_list[1]
-        assert args[0] == 'https://api.github.com/repos/test-repo/statuses/abc464aa'
-        assert kwargs['json'] == {'state': 'success',
-                                  'description': 'All good here',
-                                  'context': 'testbot:test2'}
+        kwargs['json'].pop('completed_at')  # Actual value not important
+        assert args[0] == 'https://api.github.com/repos/test-repo/check-runs'
+        assert kwargs['json'] == {'name': 'testbot:test2',
+                                  'head_sha': 'abc464aa',
+                                  'status': 'completed',
+                                  'conclusion': 'success',
+                                  'output': {'title': 'testbot:test2',
+                                             'summary': 'All good here'}}
 
     # The following test is not relevant currently since we don't skip posting
-    # statuses, due to strange caching issues with GitHub. But if we ever add
+    # checks, due to strange caching issues with GitHub. But if we ever add
     # back this functionality, the test below could come in handy.
     #
-    # def test_skip_existing_statuses(self, app, client):
+    # def test_skip_existing_checks(self, app, client):
     #
-    #     # If statuses already exist, don't post them again
+    #     # If checks already exist, don't post them again
     #
-    #     test_hook.return_value = {'test1': {'description': 'Problems here', 'state': 'failure'},
-    #                               'test2': {'description': 'All good here', 'state': 'success'}}
+    #     test_hook.return_value = {
+    #         'test1': {'description': 'Problems here', 'state': 'failure'},
+    #         'test2': {'description': 'All good here', 'state': 'success'}}
     #
     #     self.get_file_contents.return_value = CONFIG_TEMPLATE
     #
-    #     self.existing_statuses = [{'context': 'testbot:test1',
-    #                                'description': 'Problems here',
-    #                                'state': 'failure'}]
+    #     self.existing_checks = {
+    #         'total_count': 1,
+    #         'check_runs': [{'name': 'testbot:test1',
+    #                         'status': 'completed',
+    #                         'conclusion': 'failure',
+    #                         'output': {'title': 'testbot:test1',
+    #                                    'summary': 'Problems here'}}]}
     #
     #     self.send_event(client)
     #
     #     assert self.requests_post.call_count == 1
     #
     #     args, kwargs = self.requests_post.call_args_list[0]
-    #     assert args[0] == 'https://api.github.com/repos/test-repo/statuses/abc464aa'
-    #     assert kwargs['json'] == {'state': 'success',
-    #                               'description': 'All good here',
-    #                               'context': 'testbot:test2'}
+    #     kwargs['json'].pop('completed_at')  # Actual value not important
+    #     assert args[0] == 'https://api.github.com/repos/test-repo/check-runs'
+    #     assert kwargs['json'] == {'name': 'testbot:test2',
+    #                               'head_sha': 'abc464aa',
+    #                               'status': 'completed',
+    #                               'conclusion': 'success',
+    #                               'output': {'title': 'testbot:test2',
+    #                                          'summary': 'All good here'}}
 
-    def test_no_skip_existing_different_statuses(self, app, client):
+    def test_no_skip_existing_different_checks(self, app, client):
 
-        # If statuses already exist but has some differences, post again
+        # If checks already exist but has some differences, post again
 
-        test_hook.return_value = {'test1': {'description': 'Problems here', 'state': 'failure'},
-                                  'test2': {'description': 'All good here', 'state': 'success'}}
+        test_hook.return_value = {
+            'test1': {'description': 'Problems here', 'state': 'failure'},
+            'test2': {'description': 'All good here', 'state': 'success'}}
 
         self.get_file_contents.return_value = CONFIG_TEMPLATE
 
-        self.existing_statuses = [{'context': 'testbot:test1',
-                                   'description': 'Problems here',
-                                   'state': 'pending'},
-                                  {'context': 'testbot:test2',
-                                   'description': 'All good here (extra comment)',
-                                   'state': 'success'},
-                                  {'context': 'travis',
-                                   'description': 'An unrelated status',
-                                   'state': 'failure'}]
+        self.existing_checks = {
+            'total_count': 3,
+            'check_runs': [{'name': 'testbot:test1',
+                            'status': 'in_progress',
+                            'conclusion': 'neutral',
+                            'output': {'title': 'testbot:test1',
+                                       'summary': 'Problems here'}},
+                           {'name': 'testbot:test2',
+                            'status': 'completed',
+                            'conclusion': 'success',
+                            'output': {'title': 'testbot:test2',
+                                       'summary': 'All good here (extra comment)'}},
+                           {'name': 'travis',
+                            'status': 'completed',
+                            'conclusion': 'failure',
+                            'output': {'title': 'travis',
+                                       'summary': 'An unrelated check'}}]}
 
         self.send_event(client)
 
         assert self.requests_post.call_count == 2
 
         args, kwargs = self.requests_post.call_args_list[0]
-        assert args[0] == 'https://api.github.com/repos/test-repo/statuses/abc464aa'
-        assert kwargs['json'] == {'state': 'failure',
-                                  'description': 'Problems here',
-                                  'context': 'testbot:test1'}
+        kwargs['json'].pop('completed_at')  # Actual value not important
+        assert args[0] == 'https://api.github.com/repos/test-repo/check-runs'
+        assert kwargs['json'] == {'name': 'testbot:test1',
+                                  'head_sha': 'abc464aa',
+                                  'status': 'completed',
+                                  'conclusion': 'failure',
+                                  'output': {'title': 'testbot:test1',
+                                             'summary': 'Problems here'}}
 
         args, kwargs = self.requests_post.call_args_list[1]
-        assert args[0] == 'https://api.github.com/repos/test-repo/statuses/abc464aa'
-        assert kwargs['json'] == {'state': 'success',
-                                  'description': 'All good here',
-                                  'context': 'testbot:test2'}
+        kwargs['json'].pop('completed_at')  # Actual value not important
+        assert args[0] == 'https://api.github.com/repos/test-repo/check-runs'
+        assert kwargs['json'] == {'name': 'testbot:test2',
+                                  'head_sha': 'abc464aa',
+                                  'status': 'completed',
+                                  'conclusion': 'success',
+                                  'output': {'title': 'testbot:test2',
+                                             'summary': 'All good here'}}
 
     def test_skip_on_labels(self, app, client):
 
@@ -230,10 +274,14 @@ class TestPullRequestHandler:
         assert self.requests_post.call_count == 1
 
         args, kwargs = self.requests_post.call_args
-        assert args[0] == 'https://api.github.com/repos/test-repo/statuses/abc464aa'
-        assert kwargs['json'] == {'state': 'failure',
-                                  'description': 'Skipping checks due to Experimental label',
-                                  'context': 'testbot'}
+        kwargs['json'].pop('completed_at')  # Actual value not important
+        assert args[0] == 'https://api.github.com/repos/test-repo/check-runs'
+        assert kwargs['json'] == {'name': 'testbot',
+                                  'head_sha': 'abc464aa',
+                                  'status': 'completed',
+                                  'conclusion': 'failure',
+                                  'output': {'title': 'testbot',
+                                             'summary': 'Skipping checks due to Experimental label'}}
 
     def test_check_returns_none(self, app, client):
         """


### PR DESCRIPTION
Follow up of #45 to actually use the `set_check` API.

TODO:
- [x] Is this what we really want?
- [x] Fix tests, if they fail.
- [ ] How to play with this before merge for all the scenarios being handled in the PR checks?