### PR TITLE
Fix stale PR script

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@
 
 * Improve logic for closing stale issues. [#69]
 
+* Removed leftover ``autoclose_stale_pull_request`` configuration item for
+  the stale pull request script.
+
 0.2 (2018-11-22)
 ----------------
 

--- a/baldrick/scripts/stale_pull_requests.py
+++ b/baldrick/scripts/stale_pull_requests.py
@@ -58,9 +58,6 @@ def process_pull_requests(repository, installation,
     repo = RepoHandler(repository, 'master', installation)
     pull_requests = repo.open_pull_requests()
 
-    # User config
-    enable_autoclose = repo.get_config_value('autoclose_stale_pull_request', True)
-
     for n in pull_requests:
 
         print(f'Checking {n}')
@@ -88,9 +85,7 @@ def process_pull_requests(repository, installation,
 
         if time_since_last_warning > close_seconds:
             comment_ids = pr.find_comments(f'{bot_name}[bot]', filter_keep=is_close_epilogue)
-            if not enable_autoclose:
-                print(f'-> Skipping pull request {n} (auto-close disabled)')
-            elif len(comment_ids) == 0:
+            if len(comment_ids) == 0:
                 print(f'-> CLOSING pull request {n}')
                 pr.set_labels(['closed-by-bot'])
                 pr.submit_comment(PULL_REQUESTS_CLOSE_EPILOGUE)


### PR DESCRIPTION
The stale PR script still used a configuration item in one place, but we shouldn't do this since the config infrastructure relies on ``current_app`` which only works inside the flask context.

Since the stale scripts are opt in anyway, as they require a cron job to be set up, and since we already removed all the other config related to the time to warn and time to close, I think this was just an oversight.