### PR TITLE
Allow specifying a single or list of actions to trigger pull_request_handler on

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,11 @@
 * Removed leftover ``autoclose_stale_pull_request`` configuration item for
   the stale pull request script.
 
+* The ``pull_request_handler`` decorator now accepts a list of actions to
+  trigger on. By default, functions decorated ``pull_request_handler`` are
+  called with any of unlabeled, labeled, synchronize, opened, milestoned, and
+  demilestoned. [#XX]
+
 0.2 (2018-11-22)
 ----------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,7 @@
 * The ``pull_request_handler`` decorator now accepts a list of actions to
   trigger on. By default, functions decorated ``pull_request_handler`` are
   called with any of unlabeled, labeled, synchronize, opened, milestoned, and
-  demilestoned. [#XX]
+  demilestoned. [#77]
 
 0.2 (2018-11-22)
 ----------------

--- a/baldrick/plugins/github_pull_requests.py
+++ b/baldrick/plugins/github_pull_requests.py
@@ -13,8 +13,8 @@ def pull_request_handler(func, actions=None):
     """
     A decorator to add functions to the pull request checker.
 
-    Functions decorated with this decorator will be passed events which match
-    the following actions:
+    By default, functions decorated with this decorator will be passed events
+    which match the following actions:
 
     * unlabeled
     * labeled
@@ -22,6 +22,9 @@ def pull_request_handler(func, actions=None):
     * opened
     * milestoned
     * demilestoned
+
+    However, you may pass in a list of strings with subsets of these actions to
+    control when the checks are run.
 
     They will be passed ``(pr_handler, repo_handler)`` and are expected to
     return a dictionary where the key is a unique string that refers to the

--- a/baldrick/plugins/tests/test_github_pull_requests.py
+++ b/baldrick/plugins/tests/test_github_pull_requests.py
@@ -3,7 +3,8 @@ from copy import copy
 from unittest.mock import MagicMock, patch, PropertyMock
 
 from baldrick.github.github_api import cfg_cache
-from baldrick.plugins.github_pull_requests import pull_request_handler, PULL_REQUEST_CHECKS
+from baldrick.plugins.github_pull_requests import (pull_request_handler,
+                                                   PULL_REQUEST_CHECKS)
 
 test_hook = MagicMock()
 
@@ -21,7 +22,9 @@ def setup_module(module):
 
 
 def teardown_module(module):
-    PULL_REQUEST_CHECKS = module.PULL_REQUEST_CHECKS_ORIG.copy()
+    global PULL_REQUEST_CHECKS
+    PULL_REQUEST_CHECKS.clear()
+    PULL_REQUEST_CHECKS.update(module.PULL_REQUEST_CHECKS_ORIG)
 
 
 class TestPullRequestHandler:

--- a/baldrick/plugins/tests/test_github_pull_requests.py
+++ b/baldrick/plugins/tests/test_github_pull_requests.py
@@ -22,7 +22,6 @@ def setup_module(module):
 
 
 def teardown_module(module):
-    global PULL_REQUEST_CHECKS
     PULL_REQUEST_CHECKS.clear()
     PULL_REQUEST_CHECKS.update(module.PULL_REQUEST_CHECKS_ORIG)
 

--- a/baldrick/plugins/tests/test_github_pull_requests.py
+++ b/baldrick/plugins/tests/test_github_pull_requests.py
@@ -21,7 +21,7 @@ def setup_module(module):
 
 
 def teardown_module(module):
-    PULL_REQUEST_CHECKS[:] = module.PULL_REQUEST_CHECKS_ORIG[:]
+    PULL_REQUEST_CHECKS = module.PULL_REQUEST_CHECKS_ORIG.copy()
 
 
 class TestPullRequestHandler:


### PR DESCRIPTION
This changes `PULL_REQUEST_CHECKS` from a list to a dictionary so that we can use the `pull_request_handler` decorator to also specify a list of actions. This would let us trigger checks only for certain actions. This is one possible solution for astropy/astropy-bot#106, but the experts should please chime in if there is another way to solve this :)