### PR TITLE
Move over autolabel from astropy-bot

### DIFF
--- a/baldrick/plugins/github_pull_requests_autolabel.py
+++ b/baldrick/plugins/github_pull_requests_autolabel.py
@@ -71,7 +71,7 @@ def autolabel(pr_handler, repo_handler):
     upstream_repo = RepoHandler(pr_handler.repo,
                                 installation=pr_handler.installation)
 
-    al_config = upstream_repo.get_config_value("autolabel", {})
+    al_config = pr_handler.get_config_value("autolabel", {})
     if not al_config.get('enabled', False):
         return
 

--- a/baldrick/plugins/github_pull_requests_autolabel.py
+++ b/baldrick/plugins/github_pull_requests_autolabel.py
@@ -72,6 +72,9 @@ def autolabel(pr_handler, repo_handler):
                                 installation=pr_handler.installation)
 
     al_config = upstream_repo.get_config_value("autolabel", {})
+    if not al_config.get('enabled', False):
+        return
+
     files = pr_handler.get_modified_files()
 
     print('  Modified files:')
@@ -91,8 +94,6 @@ def autolabel(pr_handler, repo_handler):
     if al_config.get('subpackages', True):
         labels = get_subpackage_labels(files, all_labels)
         new_labels = new_labels.union(labels)
-
-    # TODO: add other auto-labeling logic here
 
     if new_labels:
         final_labels = list(pr_labels.union(new_labels))

--- a/baldrick/plugins/github_pull_requests_autolabel.py
+++ b/baldrick/plugins/github_pull_requests_autolabel.py
@@ -1,0 +1,102 @@
+from os import path, sep
+
+from baldrick.github.github_api import RepoHandler
+from baldrick.plugins.github_pull_requests import pull_request_handler
+
+
+def get_subpackage_labels(files, all_labels):
+    """Loop through all modified file paths and extract the path elements for
+    each of the files. Then see if any of these paths or subsets of the path
+    exist as labels in the repo. This ignores the root of the path, so that,
+    e.g., astropy/coordinates and docs/coordinates both get caught and matched
+    to a "coordinates" label. Because this also considers all cumulative subsets
+    of the path, the following all map to, e.g., a "coordinates" label:
+
+        astropy/coordinates/file.py
+        astropy/coordinates/tests/file.py
+        astropy/coordinates/stuff/tests/file.py
+        docs/coordinates/stuff/file.rst
+
+    Parameters
+    ----------
+    files : iterable
+        A list or iterable of full path names to files modified by a pull
+        request.
+    all_labels : iterable
+        A list or iterable of all labels defined for the repository.
+
+    Returns
+    -------
+    labels : set
+        A set containing all subpackage labels to be added to the pull request
+        that already exist in the input ``all_labels``.
+
+    """
+    labels = set()
+
+    for file_ in files:
+        # Each file_ is assumed to be a full path to a modified file within
+        # the repository. This then grabs the directory name of the file_,
+        # stripping off the filename itself:
+        subdir = path.dirname(file_)
+
+        # If we are in a subdirectory:
+        if subdir:
+            # Get the subdirectory root name (e.g., "packagename" or "docs"),
+            # and the rest of the path:
+            root, *subpkg = subdir.split(sep)
+
+            if subpkg:
+                # Consider all possible, cumulative path subsets:
+                for i in range(len(subpkg)):
+                    # Assume that the subpackage labels for sub-sub packages
+                    # contain dots
+                    dot_name = '.'.join(subpkg[:i + 1])
+
+                    # Only add the label if it exists in the full list of
+                    # repository labels
+                    if dot_name in all_labels:
+                        labels.add(dot_name)
+
+    return labels
+
+
+@pull_request_handler(actions=['opened'])
+def autolabel(pr_handler, repo_handler):
+
+    print(f'Running auto-labeller for {pr_handler.repo}#{pr_handler.number}')
+
+    # Note: repo_handler is the fork, we need to use the upstream repository
+    # for some tasks below.
+    upstream_repo = RepoHandler(pr_handler.repo,
+                                installation=pr_handler.installation)
+
+    al_config = upstream_repo.get_config_value("autolabel", {})
+    files = pr_handler.get_modified_files()
+
+    print('  Modified files:')
+    for file in files:
+        print(f'    - {file}')
+
+    all_labels = upstream_repo.get_all_labels()
+
+    print('  All labels: ' + ', '.join(all_labels))
+
+    pr_labels = set(pr_handler.labels)
+
+    print('  Pull request labels: ' + ', '.join(pr_labels))
+
+    new_labels = set()
+
+    if al_config.get('subpackages', True):
+        labels = get_subpackage_labels(files, all_labels)
+        new_labels = new_labels.union(labels)
+
+    # TODO: add other auto-labeling logic here
+
+    if new_labels:
+        final_labels = list(pr_labels.union(new_labels))
+        print('  Final labels to set: ' + ', '.join(final_labels))
+        pr_handler.set_labels(final_labels)
+
+    return None

--- a/baldrick/plugins/tests/test_autolabel.py
+++ b/baldrick/plugins/tests/test_autolabel.py
@@ -1,0 +1,82 @@
+# For these tests, we patch the repo and pull request handler directly rather
+# than the requests to the server, as we assume the repo and pull request
+# handlers are tested inside baldrick.
+
+from unittest.mock import MagicMock, patch
+
+from astropy_bot.autolabel import autolabel
+from baldrick.github.github_api import RepoHandler
+
+
+class AutolabelBase:
+
+    all_labels = ['analytic_functions', 'config', 'constants',
+                  'convolution', 'coordinates', 'cosmology',
+                  'io.ascii', 'io.fits', 'io.misc', 'io.misc.asdf',
+                  'io.registry', 'io.votable', 'modeling', 'nddata',
+                  'samp', 'stats', 'table', 'time', 'timeseries',
+                  'uncertainty', 'units', 'utils', 'visualization',
+                  'visualization.wcsaxes', 'vo', 'vo.conesearch',
+                  'wcs', 'wcs.wcsapi']
+
+    def setup_method(self, method):
+
+        self.pr_handler = MagicMock()
+        self.pr_handler.number = 1234
+        self.pr_handler.labels = ['Docs']
+        self.pr_handler.milestone = None
+        self.pr_handler.set_labels = self.set_labels
+        self.pr_handler.get_modified_files = self.get_modified_files
+
+        self.repo_handler = MagicMock()
+        self.repo_handler.get_all_labels = self.get_all_labels
+
+    # Patched methods:
+    def get_modified_files(self):
+        return self.files
+
+    def get_all_labels(self):
+        return self.all_labels
+
+    def set_labels(self, labels):
+        self.labels = labels
+
+
+class TestAutolabel1(AutolabelBase):
+    files = ['CHANGES.rst', 'astropy/io/fits/convenience.py',
+             'astropy/io/fits/fitstime.py',
+             'astropy/io/fits/tests/test_fitstime.py',
+             'astropy/coordinates/baseframe.py',
+             'astropy/visualization/wcsaxes/coordinate_helpers.py']
+
+    def test_autolabel_subpackages(self, app):
+        with app.app_context():
+            with patch.object(RepoHandler, 'get_all_labels') as p:
+                p.side_effect = self.get_all_labels
+                autolabel(self.pr_handler, self.repo_handler)
+
+        # make sure 'Docs' stays in there:
+        assert 'Docs' in self.pr_handler.labels
+
+        # now check that all the subpackage labels are added:
+        assert 'io.fits' in self.labels
+        assert 'coordinates' in self.labels
+        assert 'visualization.wcsaxes' in self.labels
+
+
+class TestAutolabel2(AutolabelBase):
+    files = ['astropy/io/fits/tests/test_thing.py',
+             'docs/units/thing.rst']
+
+    def test_autolabel_subpackages(self, app):
+        with app.app_context():
+            with patch.object(RepoHandler, 'get_all_labels') as p:
+                p.side_effect = self.get_all_labels
+                autolabel(self.pr_handler, self.repo_handler)
+
+        # make sure 'Docs' stays in there:
+        assert 'Docs' in self.pr_handler.labels
+
+        # now check that all the subpackage labels are added:
+        assert 'io.fits' in self.labels
+        assert 'units' in self.labels

--- a/template/pyproject.toml
+++ b/template/pyproject.toml
@@ -32,3 +32,8 @@
     # type_correct = ""
     # type_incorrect = ""
     # help_url = ""
+
+  [ tool.<your-bot-name>.autolabel ]
+
+    # enabled = true
+    # subpackages = False


### PR DESCRIPTION
Fix #82 

cc @adrn 

TODO:
- [ ] Change log
- [ ] How to best support arbitrary dir structure like https://github.com/hawkowl/towncrier? Also astropy/astropy-bot#108
- [ ] Packages need to actively opt in now?
- [ ] After this is merged, need to remove `autolabel.py` from `astropy-bot` and make it work with the one here.