### PR TITLE
Improvements to Checks

### DIFF
--- a/baldrick/github/github_api.py
+++ b/baldrick/github/github_api.py
@@ -130,7 +130,7 @@ class GitHubHandler:
                 repo_config = loads(file_content, tool=current_app.bot_username)
                 logger.trace(f"Got the following config from {self.repo}@{branch}: {repo_config}")
             except Exception:
-                logger.error(
+                logger.exception(
                     f"Failed to load config in {self.repo} on branch {branch}, despite finding a pyproject.toml file.")
 
             if getattr(current_app, "fall_back_config", None):

--- a/baldrick/github/github_api.py
+++ b/baldrick/github/github_api.py
@@ -248,6 +248,7 @@ class GitHubHandler:
             # These keys match the kwargs to set_check
             checks[context] = {
                 'external_id': result['external_id'],
+                'title': result['output']['title'],
                 'summary': result['output']['summary'],
                 'name': result['name'],
                 'text': result['output'].get('text'),
@@ -662,8 +663,10 @@ class PullRequestHandler(IssueHandler):
 
         Parameters
         ----------
-        commit_hash : str, optional
+        commit_hash : `str`, optional
             The commit hash to set the check on. Defaults to "head" can also be "base".
+        only_ours : `bool`, optional
+            Only return checks which were posted by this GitHub app.
         """
         if commit_hash == "head":
             commit_hash = self.head_sha

--- a/baldrick/github/github_api.py
+++ b/baldrick/github/github_api.py
@@ -526,7 +526,8 @@ class PullRequestHandler(IssueHandler):
         Parameters
         ----------
         external_id : `str`
-            The reference for this check.
+            The internal reference for this check, used to reference the check
+            later, to update it.
 
         title: `str`
             The short description of the check to be put in the status line of the PR.

--- a/baldrick/github/github_api.py
+++ b/baldrick/github/github_api.py
@@ -603,6 +603,8 @@ class PullRequestHandler(IssueHandler):
             parameters['conclusion'] = conclusion
             if completed_at is not None:
                 parameters['completed_at'] = completed_at
+            # The GitHub API does this automatically, but we do it explicitly
+            # here for consistency and for tests!
             parameters['status'] = "completed"
 
         logger.trace(f"Sending GitHub check with {parameters}")

--- a/baldrick/github/github_api.py
+++ b/baldrick/github/github_api.py
@@ -509,14 +509,14 @@ class IssueHandler(GitHubHandler):
 class PullRequestHandler(IssueHandler):
 
     # https://developer.github.com/v3/checks/runs/#create-a-check-run
-    def set_check(self, external_id, summary, name=None, text=None,
+    def set_check(self, external_id, title, name=None, summary=None, text=None,
                   commit_hash='head', details_url=None, status='queued',
                   conclusion='neutral'):
         """
         Set check status.
 
         .. note:: This method does not provide API access to full
-                  check run capability (e.g., annotation,
+                  check run capability (e.g., annotation and
                   image). Add them as needed.
 
         Parameters
@@ -524,14 +524,18 @@ class PullRequestHandler(IssueHandler):
         external_id : `str`
             The reference for this check.
 
-        summary : `str`
-            Summary of the check run.
+        title: `str`
+            The short description of the check to be put in the status line of the PR.
 
         name : `str`, optional
-            Name of the check, defaults to ``external_id`` if not specified.
+            Name of the check, defaults to ``{bot_username}:{external_id}`` if
+            not specified, is displayed first in the status line.
+
+        summary : `str`
+            Summary of the check run, displays at the top of the checks page.
 
         text : `str`, optional
-            The full body of the check
+            The full body of the check, displayed on the checks page.
 
         commit_hash: { 'head' | 'base' }, optional
             The SHA of the commit.

--- a/baldrick/github/github_api.py
+++ b/baldrick/github/github_api.py
@@ -113,6 +113,8 @@ class GitHubHandler:
             Configuration parameters.
 
         """
+        # Also default to 'master' if branch is None
+        branch = branch or 'master'
         app_config = current_app.conf.copy()
         fallback_config = Config()
         repo_config = Config()

--- a/baldrick/github/github_api.py
+++ b/baldrick/github/github_api.py
@@ -581,7 +581,7 @@ class PullRequestHandler(IssueHandler):
             output['text'] = text
 
         parameters = {'external_id': external_id, 'name': name, 'head_sha':
-                      commit_hash, 'status': status, 'output': output }
+                      commit_hash, 'status': status, 'output': output}
 
         if details_url is not None:
             parameters['details_url'] = details_url

--- a/baldrick/github/tests/test_github_api.py
+++ b/baldrick/github/tests/test_github_api.py
@@ -229,3 +229,63 @@ class TestPullRequestHandler:
             assert self.pr.has_modified(['file1.txt'])
             assert self.pr.has_modified(['file1.txt', 'notthis.txt'])
             assert not self.pr.has_modified(['notthis.txt'])
+
+
+    def test_set_check(self, app):
+        with patch("baldrick.github.github_api.PullRequestHandler.json", new_callable=PropertyMock) as json:
+            json.return_value = {'head': {'sha': 987654321},
+                                 'base': {'sha': 123456789}}
+            with patch('requests.post') as post:
+                self.pr.set_check("baldrick-1", "hello", name="test")
+                expected_json = {'external_id': 'baldrick-1',
+                                 'name': 'test',
+                                 'head_sha': 987654321,
+                                 'status': 'completed',
+                                 'output': {'title': 'hello', 'summary': ''},
+                                 'conclusion': 'neutral'}
+                post.assert_called_once_with('https://api.github.com/repos/fakerepo/doesnotexist/check-runs',
+                                             headers={'Accept': 'application/vnd.github.antiope-preview+json'},
+                                             json=expected_json)
+
+                post.reset_mock()
+
+                self.pr.set_check("baldrick-1", "hello", name="test",
+                                  commit_hash='base', text="hello world", summary="why hello")
+                expected_json = {'external_id': 'baldrick-1',
+                                 'name': 'test',
+                                 'head_sha': 123456789,
+                                 'status': 'completed',
+                                 'output': {'title': 'hello', 'summary': 'why hello', 'text': 'hello world'},
+                                 'conclusion': 'neutral'}
+                post.assert_called_once_with('https://api.github.com/repos/fakerepo/doesnotexist/check-runs',
+                                             headers={'Accept': 'application/vnd.github.antiope-preview+json'},
+                                             json=expected_json)
+
+                post.reset_mock()
+
+                self.pr.set_check("baldrick-1", "hello", name="test",
+                                  commit_hash='hello', details_url="this_is_a_url")
+                expected_json = {'external_id': 'baldrick-1',
+                                 'name': 'test',
+                                 'head_sha': 'hello',
+                                 'details_url': 'this_is_a_url',
+                                 'status': 'completed',
+                                 'output': {'title': 'hello', 'summary': ''},
+                                 'conclusion': 'neutral'}
+                post.assert_called_once_with('https://api.github.com/repos/fakerepo/doesnotexist/check-runs',
+                                             headers={'Accept': 'application/vnd.github.antiope-preview+json'},
+                                             json=expected_json)
+
+                post.reset_mock()
+
+                self.pr.set_check("baldrick-1", "hello", name="test",
+                                  status="completed", conclusion=None)
+                expected_json = {'external_id': 'baldrick-1',
+                                 'name': 'test',
+                                 'head_sha': 987654321,
+                                 'status': 'completed',
+                                 'output': {'title': 'hello', 'summary': ''},
+                                 'conclusion': 'neutral'}
+                post.assert_called_once_with('https://api.github.com/repos/fakerepo/doesnotexist/check-runs',
+                                             headers={'Accept': 'application/vnd.github.antiope-preview+json'},
+                                             json=expected_json)

--- a/baldrick/github/tests/test_github_api.py
+++ b/baldrick/github/tests/test_github_api.py
@@ -230,7 +230,6 @@ class TestPullRequestHandler:
             assert self.pr.has_modified(['file1.txt', 'notthis.txt'])
             assert not self.pr.has_modified(['notthis.txt'])
 
-
     def test_set_check(self, app):
         with patch("baldrick.github.github_api.PullRequestHandler.json", new_callable=PropertyMock) as json:
             json.return_value = {'head': {'sha': 987654321},

--- a/baldrick/plugins/github_milestones.py
+++ b/baldrick/plugins/github_milestones.py
@@ -22,6 +22,12 @@ def process_milestone(pr_handler, repo_handler):
     pass_message = mc_config.get("present_message", PRESENT_MESSAGE)
 
     if pr_handler.milestone:
-        return {'milestone': {'description': pass_message, 'state': 'success'}}
+        return {'milestone': {
+            'title': pass_message,
+            'conclusion': 'success'
+        }}
     else:
-        return {'milestone': {'description': fail_message, 'state': 'failure'}}
+        return {'milestone': {
+            'title': fail_message,
+            'conclusion': 'failure'
+        }}

--- a/baldrick/plugins/github_milestones.py
+++ b/baldrick/plugins/github_milestones.py
@@ -24,10 +24,12 @@ def process_milestone(pr_handler, repo_handler):
     if pr_handler.milestone:
         return {'milestone': {
             'title': pass_message,
-            'conclusion': 'success'
+            'conclusion': 'success',
+            'summary': mc_config.get("present_message_long", '')
         }}
     else:
         return {'milestone': {
             'title': fail_message,
-            'conclusion': 'failure'
+            'conclusion': 'failure',
+            'summary': mc_config.get("missing_message_long", '')
         }}

--- a/baldrick/plugins/github_milestones.py
+++ b/baldrick/plugins/github_milestones.py
@@ -23,12 +23,14 @@ def process_milestone(pr_handler, repo_handler):
 
     if pr_handler.milestone:
         return {'milestone': {
+            'name': "milestone: present",
             'title': pass_message,
             'conclusion': 'success',
             'summary': mc_config.get("present_message_long", '')
         }}
     else:
         return {'milestone': {
+            'name': "milestone: absent",
             'title': fail_message,
             'conclusion': 'failure',
             'summary': mc_config.get("missing_message_long", '')

--- a/baldrick/plugins/github_pull_requests.py
+++ b/baldrick/plugins/github_pull_requests.py
@@ -187,7 +187,8 @@ def process_pull_request(repository, number, installation, action,
 
     # Any keys left in results are new checks we haven't sent on this commit yet.
     for external_id, details in sorted(new_results.items()):
-        skip = check.pop("skip_if_missing", False)
+        skip = details.pop("skip_if_missing", False)
+        logger.trace(f"{details} skip is {skip}")
         if not skip:
             pr_handler.set_check(external_id, status="completed", **details)
 

--- a/baldrick/plugins/github_pull_requests.py
+++ b/baldrick/plugins/github_pull_requests.py
@@ -177,12 +177,10 @@ def process_pull_request(repository, number, installation, action,
             pr_handler.set_check(**check)
         else:
             # If check is in existing_checks but not results mark it as skipped.
-            logging.debug(check)
             check.update({
                 'title': 'This check has been skipped.',
                 'status': 'completed',
                 'conclusion': 'neutral'})
-            logging.debug(check)
             pr_handler.set_check(**check)
 
     # Any keys left in results are new checks we haven't sent on this commit yet.

--- a/baldrick/plugins/github_pull_requests.py
+++ b/baldrick/plugins/github_pull_requests.py
@@ -162,7 +162,7 @@ def process_pull_request(repository, number, installation, action,
         # return old status messages, so we avoid doing that.
 
         pr_handler.set_check(
-            full_context, details['description'],
+            full_context, details['description'], text=details.get("text"),
             details_url=details.get('target_url'), status='completed',
             conclusion=details['state'])
 

--- a/baldrick/plugins/github_pull_requests.py
+++ b/baldrick/plugins/github_pull_requests.py
@@ -145,17 +145,15 @@ def process_pull_request(repository, number, installation, action,
                 # It's possible that the hook returns {}
                 for context, check in result.items():
                     if check is not None:
-                        title = None
-                        if 'title' not in check:
-                            title = check.pop('description', None)
+                        title = check.pop('description', None)
+                        title = check.pop('title', title)
                         if title:
                             logger.warning(
                                 f"'description' is deprecated as a key in the return value from {function},"
                                 " it will be interpreted as 'title'")
                             check['title'] = title
-                        conclusion = None
-                        if 'state' not in check:
-                            conclusion = check.pop('state', None)
+                        conclusion = check.pop('state', None)
+                        conclusion = check.pop('conclusion', conclusion)
                         if conclusion:
                             logger.warning(
                                 f"'state' is deprecated as a key in the return value from {function},"

--- a/baldrick/plugins/github_pull_requests.py
+++ b/baldrick/plugins/github_pull_requests.py
@@ -146,19 +146,19 @@ def process_pull_request(repository, number, installation, action,
                 for context, check in result.items():
                     if check is not None:
                         title = check.pop('description', None)
-                        title = check.pop('title', title)
                         if title:
                             logger.warning(
                                 f"'description' is deprecated as a key in the return value from {function},"
                                 " it will be interpreted as 'title'")
                             check['title'] = title
+                        check['title'] = check.pop('title', title)
                         conclusion = check.pop('state', None)
-                        conclusion = check.pop('conclusion', conclusion)
                         if conclusion:
                             logger.warning(
                                 f"'state' is deprecated as a key in the return value from {function},"
                                 "it will be interpreted as 'conclusion'.")
                             check['conclusion'] = conclusion
+                        check['conclusion'] = check.pop('conclusion', conclusion)
                     result[context] = check
                 results.update(result)
 

--- a/baldrick/plugins/github_pull_requests.py
+++ b/baldrick/plugins/github_pull_requests.py
@@ -38,12 +38,13 @@ def pull_request_handler(actions=None):
     * ``conclusion`` is a string giving the state for the latest commit (one of
       ``success``, ``failure``, ``neutral``, ``cancelled``, ``timed_out``, or
       ``action_required``).
-    * ``title``: the message to be shown in the status line of the PR
+    * ``title`` is the message to be shown in the status line of the PR
 
     Common optional ones are:
+
     * ``name``:: The name of the check in the status line of the PR.
     * ``summary``:: A summary of the check to be put on the check page.
-    * ``target_url``: a URL to link to in the status
+    * ``target_url``: A URL to link to in the status.
     """
 
     if callable(actions):

--- a/baldrick/plugins/github_pull_requests.py
+++ b/baldrick/plugins/github_pull_requests.py
@@ -31,13 +31,19 @@ def pull_request_handler(actions=None):
 
     They will be passed ``(pr_handler, repo_handler)`` and are expected to
     return a dictionary where the key is a unique string that refers to the
-    specific check that has been made, and the values are dictionaries with
-    the following keys:
+    specific check that has been made, and the values are dictionaries with any
+    arguments to the `~baldrick.github.github_api.PullRequestHandler.set_check`
+    method. Required ones are:
 
-    * ``status`` is a string giving the state for the latest commit (one of
-      ``success``, ``failure``, ``error``, or ``pending``).
-    * ``message``: the message to be shown in the status
-    * ``target_url`` (optional): a URL to link to in the status
+    * ``conclusion`` is a string giving the state for the latest commit (one of
+      ``success``, ``failure``, ``neutral``, ``cancelled``, ``timed_out``, or
+      ``action_required``).
+    * ``title``: the message to be shown in the status line of the PR
+
+    Common optional ones are:
+    * ``name``:: The name of the check in the status line of the PR.
+    * ``summary``:: A summary of the check to be put on the check page.
+    * ``target_url``: a URL to link to in the status
     """
 
     if callable(actions):

--- a/baldrick/plugins/github_pull_requests.py
+++ b/baldrick/plugins/github_pull_requests.py
@@ -178,9 +178,9 @@ def process_pull_request(repository, number, installation, action,
 
     # Also set the general 'single' status check as a skipped check if it
     # is present
-    if current_app.bot_username in existing_checks.keys():
+    if current_app.bot_username in new_results.keys():
         check.update({
-            'title': 'This check has been skipped',
+            'title': 'This check has been skipped.',
             'commit_hash': 'head',
             'status': 'completed',
             'conclusion': 'neutral'})

--- a/baldrick/plugins/github_pull_requests.py
+++ b/baldrick/plugins/github_pull_requests.py
@@ -153,7 +153,6 @@ def process_pull_request(repository, number, installation, action,
                     result[context] = check
                 results.update(result)
 
-
     # Get existing checks from our app, for the 'head' commit
     existing_checks = pr_handler.list_checks(only_ours=True)
     # For each existing check, see if it needs updating or skipping
@@ -173,11 +172,9 @@ def process_pull_request(repository, number, installation, action,
                 'conclusion': 'neutral'})
             pr_handler.set_check(**check)
 
-
     # Any keys left in results are new checks we haven't sent on this commit yet.
     for external_id, details in sorted(new_results.items()):
         pr_handler.set_check(external_id, status="completed", **details)
-
 
     # Also set the general 'single' status check as a skipped check if it
     # is present
@@ -188,7 +185,6 @@ def process_pull_request(repository, number, installation, action,
             'status': 'completed',
             'conclusion': 'neutral'})
         pr_handler.set_check(**check)
-
 
     # Special message for a special day
     not_boring = pr_handler.get_config_value('not_boring', cfg_default=True)

--- a/baldrick/plugins/github_pull_requests.py
+++ b/baldrick/plugins/github_pull_requests.py
@@ -42,9 +42,9 @@ def pull_request_handler(actions=None):
 
     Common optional ones are:
 
-    * ``name``:: The name of the check in the status line of the PR.
-    * ``summary``:: A summary of the check to be put on the check page.
-    * ``target_url``: A URL to link to in the status.
+    * ``name`` : The name of the check in the status line of the PR.
+    * ``summary`` : A summary of the check to be put on the check page.
+    * ``target_url`` : A URL to link to in the status.
     """
 
     if callable(actions):
@@ -145,13 +145,17 @@ def process_pull_request(repository, number, installation, action,
                 # It's possible that the hook returns {}
                 for context, check in result.items():
                     if check is not None:
-                        title = check.pop('description', None)
+                        title = None
+                        if 'title' not in check:
+                            title = check.pop('description', None)
                         if title:
                             logger.warning(
                                 f"'description' is deprecated as a key in the return value from {function},"
                                 " it will be interpreted as 'title'")
                             check['title'] = title
-                        conclusion = check.pop('state', None)
+                        conclusion = None
+                        if 'state' not in check:
+                            conclusion = check.pop('state', None)
                         if conclusion:
                             logger.warning(
                                 f"'state' is deprecated as a key in the return value from {function},"
@@ -186,6 +190,7 @@ def process_pull_request(repository, number, installation, action,
     # Also set the general 'single' status check as a skipped check if it
     # is present
     if current_app.bot_username in new_results.keys():
+        check = new_results[current_app.bot_username]
         check.update({
             'title': 'This check has been skipped.',
             'commit_hash': 'head',

--- a/baldrick/plugins/github_towncrier_changelog.py
+++ b/baldrick/plugins/github_towncrier_changelog.py
@@ -148,7 +148,7 @@ def process_towncrier_changelog(pr_handler, repo_handler):
     elif not matching_file:
 
         messages['missing_file'] = {
-            'name': cl_config.get('changelog_missing_name', "changelog: Missing"),
+            'name': cl_config.get('changelog_missing_name', "changelog: missing"),
             'title': cl_config.get('changelog_missing', CHANGELOG_MISSING),
             'summary': cl_config.get('changelog_missing_long', ''),
             'conclusion': 'failure'
@@ -157,7 +157,7 @@ def process_towncrier_changelog(pr_handler, repo_handler):
     else:
         all_passes = True
         if check_changelog_type(types, matching_file):
-            messages['wrong_type'] = {'name': cl_config.get('type_correct_name', 'changelog: Type correct'),
+            messages['wrong_type'] = {'name': cl_config.get('type_correct_name', 'changelog: type correct'),
                                       'title': cl_config.get('type_correct', TYPE_CORRECT),
                                       'summary': cl_config.get('type_correct_long', ''),
                                       'conclusion': 'success',
@@ -165,7 +165,7 @@ def process_towncrier_changelog(pr_handler, repo_handler):
         else:
             all_passes = False
             messages['wrong_type'] = {'name': cl_config.get('type_incorrect_name',
-                                                            'changelog: Type incorrect'),
+                                                            'changelog: type incorrect'),
                                       'title': cl_config.get('type_incorrect', TYPE_INCORRECT),
                                       'summary': cl_config.get('type_incorrect_long', ''),
                                       'conclusion': 'failure'}
@@ -173,7 +173,7 @@ def process_towncrier_changelog(pr_handler, repo_handler):
         if cl_config.get('verify_pr_number', False):
             if verify_pr_number(pr_handler.number, matching_file):
                 messages['wrong_number'] = {'name': cl_config.get('number_correct_name',
-                                                                  'changelog: Number correct'),
+                                                                  'changelog: number correct'),
                                             'title': cl_config.get('number_correct', NUMBER_CORRECT),
                                             'summary': cl_config.get('number_correct_long', ''),
                                             'conclusion': 'success',
@@ -181,13 +181,13 @@ def process_towncrier_changelog(pr_handler, repo_handler):
             else:
                 all_passes = False
                 messages['wrong_number'] = {'name': cl_config.get('number_incorrect_name',
-                                                                  'changelog: Number not PR number'),
+                                                                  'changelog: number not pull request number'),
                                             'title': cl_config.get('number_incorrect', NUMBER_INCORRECT),
                                             'summary': cl_config.get('number_incorrect_long', ''),
                                             'conclusion': 'failure'}
 
         messages['missing_file'] = {
-            'name': cl_config.get('changelog_exists_name', 'changelog: Found'),
+            'name': cl_config.get('changelog_exists_name', 'changelog: found'),
             'title': cl_config.get('changelog_exists', CHANGELOG_EXISTS),
             'summary': cl_config.get('changelog_exists_long', ''),
             'conclusion': 'success',

--- a/baldrick/plugins/github_towncrier_changelog.py
+++ b/baldrick/plugins/github_towncrier_changelog.py
@@ -144,27 +144,44 @@ def process_towncrier_changelog(pr_handler, repo_handler):
 
     elif not matching_file:
 
-        messages['missing_file'] = {'description': cl_config.get('changelog_missing', CHANGELOG_MISSING),
-                                    'state': 'failure'}
+        messages['missing_file'] = {
+            'name': cl_config.get('changelog_missing_name', "changelog: Missing entry"),
+            'title': cl_config.get('changelog_missing', CHANGELOG_MISSING),
+            'summary': cl_config.get('changelog_missing_long', ''),
+            'conclusion': 'failure'
+        }
 
     else:
 
-        messages['missing_file'] = {'description': cl_config.get('changelog_exists', CHANGELOG_EXISTS),
-                                    'state': 'success'}
+        messages['missing_file'] = {
+            'name': cl_config.get('changelog_exists_name', 'changelog: Found'),
+            'title': cl_config.get('changelog_exists', CHANGELOG_EXISTS),
+            'summary': cl_config.get('changelog_exists_long', ''),
+            'conclusion': 'success'
+            }
 
         if check_changelog_type(types, matching_file):
-            messages['wrong_type'] = {'description': cl_config.get('type_correct', TYPE_CORRECT),
-                                      'state': 'success'}
+            messages['wrong_type'] = {'name': cl_config.get('type_correct_name', 'changelog: Type correct'),
+                                      'title': cl_config.get('type_correct', TYPE_CORRECT),
+                                      'summary': cl_config.get('type_correct_long', ''),
+                                      'conclusion': 'success'}
         else:
-            messages['wrong_type'] = {'description': cl_config.get('type_incorrect', TYPE_INCORRECT),
-                                      'state': 'failure'}
+            messages['wrong_type'] = {'name': cl_config.get('type_incorrect_name', 'changelog: Type incorrect'),
+                                      'title': cl_config.get('type_incorrect', TYPE_INCORRECT),
+                                      'summary': cl_config.get('type_incorrect_long', ''),
+                                      'conclusion': 'failure'}
 
-        if cl_config.get('verify_pr_number', False) and not verify_pr_number(pr_handler.number, matching_file):
-            messages['wrong_number'] = {'description': cl_config.get('number_incorrect', NUMBER_INCORRECT),
-                                        'state': 'failure'}
-        else:
-            messages['wrong_number'] = {'description': cl_config.get('number_correc', NUMBER_CORRECT),
-                                        'state': 'success'}
+        if cl_config.get('verify_pr_number', False):
+            if verify_pr_number(pr_handler.number, matching_file):
+                messages['wrong_number'] = {'name': cl_config.get('number_incorrect_name', 'changelog: Number not PR number'),
+                                            'title': cl_config.get('number_incorrect', NUMBER_INCORRECT),
+                                            'summary': cl_config.get('number_incorrect_long', ''),
+                                            'conclusion': 'failure'}
+            else:
+                messages['wrong_number'] = {'name': cl_config.get('number_correct_name', 'changelog: Number correct'),
+                                            'title': cl_config.get('number_correct', NUMBER_CORRECT),
+                                            'summary': cl_config.get('number_correct_long', ''),
+                                            'conclusion': 'success'}
 
     # Add help URL
     for message in messages.values():

--- a/baldrick/plugins/github_towncrier_changelog.py
+++ b/baldrick/plugins/github_towncrier_changelog.py
@@ -148,7 +148,7 @@ def process_towncrier_changelog(pr_handler, repo_handler):
     elif not matching_file:
 
         messages['missing_file'] = {
-            'name': cl_config.get('changelog_missing_name', "changelog: missing"),
+            'name': cl_config.get('changelog_missing_name', "changelog: absent"),
             'title': cl_config.get('changelog_missing', CHANGELOG_MISSING),
             'summary': cl_config.get('changelog_missing_long', ''),
             'conclusion': 'failure'
@@ -157,7 +157,8 @@ def process_towncrier_changelog(pr_handler, repo_handler):
     else:
         all_passes = True
         if check_changelog_type(types, matching_file):
-            messages['wrong_type'] = {'name': cl_config.get('type_correct_name', 'changelog: type correct'),
+            messages['wrong_type'] = {'name': cl_config.get('type_correct_name',
+                                                            'changelog: type correct'),
                                       'title': cl_config.get('type_correct', TYPE_CORRECT),
                                       'summary': cl_config.get('type_correct_long', ''),
                                       'conclusion': 'success',

--- a/baldrick/plugins/github_towncrier_changelog.py
+++ b/baldrick/plugins/github_towncrier_changelog.py
@@ -158,7 +158,7 @@ def process_towncrier_changelog(pr_handler, repo_handler):
             'title': cl_config.get('changelog_exists', CHANGELOG_EXISTS),
             'summary': cl_config.get('changelog_exists_long', ''),
             'conclusion': 'success'
-            }
+        }
 
         if check_changelog_type(types, matching_file):
             messages['wrong_type'] = {'name': cl_config.get('type_correct_name', 'changelog: Type correct'),

--- a/baldrick/plugins/tests/test_github_milestones.py
+++ b/baldrick/plugins/tests/test_github_milestones.py
@@ -60,8 +60,8 @@ class TestMilestonePlugin:
 
         assert "milestone" in ret
         assert len(ret) == 1
-        assert ret['milestone']['state'] == "success"
-        assert ret['milestone']['text'] == "milestone present"
+        assert ret['milestone']['conclusion'] == "success"
+        assert ret['milestone']['title'] == "milestone present"
 
     def test_milestone_absent(self, app):
 
@@ -72,8 +72,8 @@ class TestMilestonePlugin:
 
         assert "milestone" in ret
         assert len(ret) == 1
-        assert ret['milestone']['state'] == "failure"
-        assert ret['milestone']['text'] == "missing milestone"
+        assert ret['milestone']['conclusion'] == "failure"
+        assert ret['milestone']['title'] == "missing milestone"
 
     def test_milestone_present_default(self, app):
 
@@ -85,8 +85,8 @@ class TestMilestonePlugin:
 
         assert "milestone" in ret
         assert len(ret) == 1
-        assert ret['milestone']['state'] == "success"
-        assert ret['milestone']['text'] == PRESENT_MESSAGE
+        assert ret['milestone']['conclusion'] == "success"
+        assert ret['milestone']['title'] == PRESENT_MESSAGE
 
     def test_milestone_absent_default(self, app):
 
@@ -96,8 +96,8 @@ class TestMilestonePlugin:
 
         assert "milestone" in ret
         assert len(ret) == 1
-        assert ret['milestone']['state'] == "failure"
-        assert ret['milestone']['text'] == MISSING_MESSAGE
+        assert ret['milestone']['conclusion'] == "failure"
+        assert ret['milestone']['title'] == MISSING_MESSAGE
 
     def test_no_config(self, app):
         self.get_file_contents.return_value = CONFIG_TEMPLATE_MISSING

--- a/baldrick/plugins/tests/test_github_milestones.py
+++ b/baldrick/plugins/tests/test_github_milestones.py
@@ -61,7 +61,7 @@ class TestMilestonePlugin:
         assert "milestone" in ret
         assert len(ret) == 1
         assert ret['milestone']['state'] == "success"
-        assert ret['milestone']['description'] == "milestone present"
+        assert ret['milestone']['text'] == "milestone present"
 
     def test_milestone_absent(self, app):
 
@@ -73,7 +73,7 @@ class TestMilestonePlugin:
         assert "milestone" in ret
         assert len(ret) == 1
         assert ret['milestone']['state'] == "failure"
-        assert ret['milestone']['description'] == "missing milestone"
+        assert ret['milestone']['text'] == "missing milestone"
 
     def test_milestone_present_default(self, app):
 
@@ -86,7 +86,7 @@ class TestMilestonePlugin:
         assert "milestone" in ret
         assert len(ret) == 1
         assert ret['milestone']['state'] == "success"
-        assert ret['milestone']['description'] == PRESENT_MESSAGE
+        assert ret['milestone']['text'] == PRESENT_MESSAGE
 
     def test_milestone_absent_default(self, app):
 
@@ -97,7 +97,7 @@ class TestMilestonePlugin:
         assert "milestone" in ret
         assert len(ret) == 1
         assert ret['milestone']['state'] == "failure"
-        assert ret['milestone']['description'] == MISSING_MESSAGE
+        assert ret['milestone']['text'] == MISSING_MESSAGE
 
     def test_no_config(self, app):
         self.get_file_contents.return_value = CONFIG_TEMPLATE_MISSING

--- a/baldrick/plugins/tests/test_github_pull_requests.py
+++ b/baldrick/plugins/tests/test_github_pull_requests.py
@@ -119,7 +119,6 @@ class TestPullRequestHandler:
         assert self.requests_post.call_count == 2
 
         args, kwargs = self.requests_post.call_args_list[0]
-        kwargs['json'].pop('completed_at')  # Actual value not important
         assert args[0] == 'https://api.github.com/repos/test-repo/check-runs'
         assert kwargs['json'] == {'name': 'testbot:test1',
                                   'head_sha': 'abc464aa',
@@ -130,7 +129,6 @@ class TestPullRequestHandler:
                                              'summary': ''}}
 
         args, kwargs = self.requests_post.call_args_list[1]
-        kwargs['json'].pop('completed_at')  # Actual value not important
         assert args[0] == 'https://api.github.com/repos/test-repo/check-runs'
         assert kwargs['json'] == {'name': 'testbot:test2',
                                   'head_sha': 'abc464aa',
@@ -155,7 +153,6 @@ class TestPullRequestHandler:
         assert self.requests_post.call_count == 2
 
         args, kwargs = self.requests_post.call_args_list[0]
-        kwargs['json'].pop('completed_at')  # Actual value not important
         assert args[0] == 'https://api.github.com/repos/test-repo/check-runs'
         assert kwargs['json'] == {'name': 'testbot:test1',
                                   'head_sha': 'abc464aa',
@@ -166,7 +163,6 @@ class TestPullRequestHandler:
                                              'summary': ''}}
 
         args, kwargs = self.requests_post.call_args_list[1]
-        kwargs['json'].pop('completed_at')  # Actual value not important
         assert args[0] == 'https://api.github.com/repos/test-repo/check-runs'
         assert kwargs['json'] == {'name': 'testbot:test2',
                                   'head_sha': 'abc464aa',
@@ -204,7 +200,6 @@ class TestPullRequestHandler:
         assert self.requests_post.call_count == 1
 
         args, kwargs = self.requests_post.call_args_list[0]
-        kwargs['json'].pop('completed_at')  # Actual value not important
         assert args[0] == 'https://api.github.com/repos/test-repo/check-runs'
         assert kwargs['json'] == {'name': 'testbot:test2',
                                   'head_sha': 'abc464aa',
@@ -218,7 +213,6 @@ class TestPullRequestHandler:
         assert self.requests_patch.call_count == 1
 
         args, kwargs = self.requests_patch.call_args_list[0]
-        kwargs['json'].pop('completed_at')  # Actual value not important
         assert args[0].startswith('https://api.github.com/repos/test-repo/check-runs')
         assert kwargs['json'] == {'name': 'testbot:test1',
                                   'head_sha': 'abc464aa',
@@ -273,7 +267,6 @@ class TestPullRequestHandler:
         assert self.requests_patch.call_count == 2
 
         args, kwargs = self.requests_patch.call_args_list[0]
-        kwargs['json'].pop('completed_at')  # Actual value not important
         assert args[0].startswith('https://api.github.com/repos/test-repo/check-runs')
         assert kwargs['json'] == {'name': 'testbot:test1',
                                   'head_sha': 'abc464aa',
@@ -284,7 +277,6 @@ class TestPullRequestHandler:
                                              'summary': ''}}
 
         args, kwargs = self.requests_patch.call_args_list[1]
-        kwargs['json'].pop('completed_at')  # Actual value not important
         assert args[0].startswith('https://api.github.com/repos/test-repo/check-runs')
         assert kwargs['json'] == {'name': 'testbot:test2',
                                   'head_sha': 'abc464aa',
@@ -310,7 +302,6 @@ class TestPullRequestHandler:
         assert self.requests_post.call_count == 1
 
         args, kwargs = self.requests_post.call_args
-        kwargs['json'].pop('completed_at')  # Actual value not important
         assert args[0].startswith('https://api.github.com/repos/test-repo/check-runs')
         assert kwargs['json'] == {'name': 'testbot',
                                   'external_id': 'testbot',

--- a/baldrick/plugins/tests/test_github_pull_requests.py
+++ b/baldrick/plugins/tests/test_github_pull_requests.py
@@ -38,6 +38,7 @@ class TestPullRequestHandler:
 
         self.requests_get_mock = patch('requests.get', self._requests_get)
         self.requests_post_mock = patch('requests.post')
+        self.requests_patch_mock = patch('requests.patch')
         self.get_file_contents_mock = patch('baldrick.github.github_api.GitHubHandler.get_file_contents')
         self.get_installation_token_mock = patch('baldrick.github.github_auth.get_installation_token')
         self.labels_mock = patch('baldrick.github.github_api.PullRequestHandler.labels',
@@ -45,6 +46,7 @@ class TestPullRequestHandler:
 
         self.requests_get = self.requests_get_mock.start()
         self.requests_post = self.requests_post_mock.start()
+        self.requests_patch = self.requests_patch_mock.start()
         self.get_file_contents = self.get_file_contents_mock.start()
         self.get_installation_token = self.get_installation_token_mock.start()
         self.labels = self.labels_mock.start()
@@ -95,7 +97,7 @@ class TestPullRequestHandler:
         # Test case where the config doesn't give a default message, and the
         # registered handlers don't return any checks
 
-        test_hook.return_value = {}
+        test_hook.return_value = None
         self.get_file_contents.return_value = CONFIG_TEMPLATE
 
         self.send_event(client)
@@ -123,8 +125,9 @@ class TestPullRequestHandler:
                                   'head_sha': 'abc464aa',
                                   'status': 'completed',
                                   'conclusion': 'success',
-                                  'output': {'title': 'testbot:test1',
-                                             'summary': 'No problem'}}
+                                  'external_id': 'test1',
+                                  'output': {'title': 'No problem',
+                                             'summary': ''}}
 
         args, kwargs = self.requests_post.call_args_list[1]
         kwargs['json'].pop('completed_at')  # Actual value not important
@@ -133,8 +136,9 @@ class TestPullRequestHandler:
                                   'head_sha': 'abc464aa',
                                   'status': 'completed',
                                   'conclusion': 'success',
-                                  'output': {'title': 'testbot:test2',
-                                             'summary': 'All good here'}}
+                                  'external_id': 'test2',
+                                  'output': {'title': 'All good here',
+                                             'summary': ''}}
 
     def test_one_failure(self, app, client):
 
@@ -157,8 +161,9 @@ class TestPullRequestHandler:
                                   'head_sha': 'abc464aa',
                                   'status': 'completed',
                                   'conclusion': 'failure',
-                                  'output': {'title': 'testbot:test1',
-                                             'summary': 'Problems here'}}
+                                  'external_id': 'test1',
+                                  'output': {'title': 'Problems here',
+                                             'summary': ''}}
 
         args, kwargs = self.requests_post.call_args_list[1]
         kwargs['json'].pop('completed_at')  # Actual value not important
@@ -167,8 +172,9 @@ class TestPullRequestHandler:
                                   'head_sha': 'abc464aa',
                                   'status': 'completed',
                                   'conclusion': 'success',
-                                  'output': {'title': 'testbot:test2',
-                                             'summary': 'All good here'}}
+                                  'external_id': 'test2',
+                                  'output': {'title': 'All good here',
+                                             'summary': ''}}
 
     # The following test is not relevant currently since we don't skip posting
     # checks, due to strange caching issues with GitHub. But if we ever add
@@ -221,42 +227,56 @@ class TestPullRequestHandler:
             'check_runs': [{'name': 'testbot:test1',
                             'status': 'in_progress',
                             'conclusion': 'neutral',
-                            'output': {'title': 'testbot:test1',
-                                       'summary': 'Problems here'}},
+                            'output': {'title': 'Problems here',
+                                       'summary': ''},
+                            'head_sha': 'abc464aa',
+                            'external_id': 'test1',
+                            'id': 1,
+                            'app': {'id': app.integration_id}},
                            {'name': 'testbot:test2',
                             'status': 'completed',
                             'conclusion': 'success',
-                            'output': {'title': 'testbot:test2',
-                                       'summary': 'All good here (extra comment)'}},
+                            'output': {'title': 'All good here (extra comment)',
+                                       'summary': ''},
+                            'head_sha': 'abc464aa',
+                            'external_id': 'test2',
+                            'id': 2,
+                            'app': {'id': app.integration_id}},
                            {'name': 'travis',
                             'status': 'completed',
                             'conclusion': 'failure',
                             'output': {'title': 'travis',
-                                       'summary': 'An unrelated check'}}]}
+                                       'summary': 'An unrelated check'},
+                            'head_sha': 'abc464aa',
+                            'external_id': 'travis',
+                            'id': 3,
+                            'app': {'id': 999999}}]}
 
         self.send_event(client)
 
-        assert self.requests_post.call_count == 2
+        assert self.requests_patch.call_count == 2
 
-        args, kwargs = self.requests_post.call_args_list[0]
+        args, kwargs = self.requests_patch.call_args_list[0]
         kwargs['json'].pop('completed_at')  # Actual value not important
-        assert args[0] == 'https://api.github.com/repos/test-repo/check-runs'
+        assert args[0].startswith('https://api.github.com/repos/test-repo/check-runs')
         assert kwargs['json'] == {'name': 'testbot:test1',
                                   'head_sha': 'abc464aa',
                                   'status': 'completed',
                                   'conclusion': 'failure',
-                                  'output': {'title': 'testbot:test1',
-                                             'summary': 'Problems here'}}
+                                  'external_id': 'test1',
+                                  'output': {'title': 'Problems here',
+                                             'summary': ''}}
 
-        args, kwargs = self.requests_post.call_args_list[1]
+        args, kwargs = self.requests_patch.call_args_list[1]
         kwargs['json'].pop('completed_at')  # Actual value not important
-        assert args[0] == 'https://api.github.com/repos/test-repo/check-runs'
+        assert args[0].startswith('https://api.github.com/repos/test-repo/check-runs')
         assert kwargs['json'] == {'name': 'testbot:test2',
                                   'head_sha': 'abc464aa',
                                   'status': 'completed',
                                   'conclusion': 'success',
-                                  'output': {'title': 'testbot:test2',
-                                             'summary': 'All good here'}}
+                                  'external_id': 'test2',
+                                  'output': {'title': 'All good here',
+                                             'summary': ''}}
 
     def test_skip_on_labels(self, app, client):
 
@@ -275,13 +295,13 @@ class TestPullRequestHandler:
 
         args, kwargs = self.requests_post.call_args
         kwargs['json'].pop('completed_at')  # Actual value not important
-        assert args[0] == 'https://api.github.com/repos/test-repo/check-runs'
+        assert args[0].startswith('https://api.github.com/repos/test-repo/check-runs')
         assert kwargs['json'] == {'name': 'testbot',
+                                  'external_id': 'testbot',
                                   'head_sha': 'abc464aa',
                                   'status': 'completed',
                                   'conclusion': 'failure',
-                                  'output': {'title': 'testbot',
-                                             'summary': 'Skipping checks due to Experimental label'}}
+                                  'output': {'title': 'Skipping checks due to Experimental label', 'summary': ''}}
 
     def test_check_returns_none(self, app, client):
         """

--- a/baldrick/plugins/tests/test_github_towncrier_changelog.py
+++ b/baldrick/plugins/tests/test_github_towncrier_changelog.py
@@ -54,4 +54,4 @@ class TestTowncrierPlugin:
             messages = process_towncrier_changelog(self.pr_handler, self.repo_handler)
 
         for message in messages.values():
-            assert message['state'] == 'success'
+            assert message['conclusion'] == 'success'

--- a/doc/plugins.rst
+++ b/doc/plugins.rst
@@ -97,7 +97,7 @@ use the ``missing_message = "..."`` and ``present_message = "..."`` configuratio
 items.
 
 If you wish to set a longer message to be shown on the checks tab, you can set
-``missing_message_long=`` and ``present_message_long``.
+``missing_message_long`` and ``present_message_long``.
 
 Towncrier changelog checker
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/plugins.rst
+++ b/doc/plugins.rst
@@ -96,6 +96,9 @@ If you wish to customize the message shown in the results of the check, you can
 use the ``missing_message = "..."`` and ``present_message = "..."`` configuration
 items.
 
+If you wish to set a longer message to be shown on the checks tab, you can set
+``missing_message_long=`` and ``present_message_long``.
+
 Towncrier changelog checker
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -133,6 +136,10 @@ the following parameters:
 * ``type_correct = "..."`` and ``type_incorrect = "..."``: the messages
   to use when a changelog entry is not of the right type.
 
+Each of these configuration options has a ``_long`` equivalent, i.e.
+``changelog_missing_long``, which will be displayed on the checks page to
+provide more details.
+
 Custom plugin
 ^^^^^^^^^^^^^
 
@@ -155,6 +162,8 @@ the class names to find out the available properties/methods).
 Your function should then return either `None` (no check results), or
 a dictionary where each key is the code name for one of the checks (this will
 be used to match checks with previous checks, so make sure this is consistent
-across calls), and the value should be a dictionary with two entries: ``state``,
-which can be set to ``'failure'`` or ``'success'``, and ``description``, which
-gives a description of the check results.
+across calls), and the value should be a dictionary with at least two entries:
+``conclusion``, which can be set to ``success``, ``failure``, ``neutral``,
+``cancelled``, ``timed_out``, or, ``action_required`` and ``title``, which sets
+the description of the check on the status line. Other keys in this dictionary
+will be passed to the `baldrick.github.PullRequestHandler.set_check` method.


### PR DESCRIPTION
This PR implements the following main things:

1. Use `external_id` on checks to allow us to keep track of which checks we have posted on what commits.
2. Use `list_checks` to get all the previous checks we have posted and be able to update them.
3. Allow plugins to set `name` on checks, this gives the plugin full control over the status line in the PR, this is now possible because we are using `external_id` to match to previous checks.
4. Deprecate and modify the parameters passe back from pull request plugins, they can now pass back any kwargs to `set_check`.
5. Make `completed_at` optional when sending a check.
6. add `_long` configuration options to milestones and towncrier to allow setting the check summary for the check page.

EDIT: Fix #86 , fix #89