### PR TITLE
MNT: Do not use deprecated API, fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ script:
 
   - python setup.py check --restructuredtext
 
+  - pip install pytest -U
   - pytest -rx --flake8 --cov baldrick baldrick
 
   # Install sphinx now - this is to make sure that the tests for baldrick don't

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
   - linux
 
 python:
-  - "3.6"
+  - "3.8"
 
 install:
   - pip install .[test]

--- a/baldrick/github/github_auth.py
+++ b/baldrick/github/github_auth.py
@@ -84,7 +84,7 @@ def get_installation_token(installation):
         headers['Authorization'] = 'Bearer {0}'.format(get_json_web_token())
         headers['Accept'] = 'application/vnd.github.machine-man-preview+json'
 
-        url = 'https://api.github.com/installations/{0}/access_tokens'.format(installation)
+        url = 'https://api.github.com/app/installations/{0}/access_tokens'.format(installation)
 
         req = requests.post(url, headers=headers)
         resp = req.json()

--- a/baldrick/plugins/github_towncrier_changelog.py
+++ b/baldrick/plugins/github_towncrier_changelog.py
@@ -129,7 +129,7 @@ def process_towncrier_changelog(pr_handler, repo_handler):
 
     config = load_towncrier_config(pr_handler)
     if not config:
-        logger.info(f"No towncrier config detected in pyproject.toml, skipping.")
+        logger.info("No towncrier config detected in pyproject.toml, skipping.")
         return
 
     section_dirs = calculate_fragment_paths(config)


### PR DESCRIPTION
I think this is what https://developer.github.com/changes/2020-04-15-replacing-create-installation-access-token-endpoint/ means?