### PR TITLE
Rephrase missing milestone

### DIFF
--- a/baldrick/plugins/github_milestones.py
+++ b/baldrick/plugins/github_milestones.py
@@ -2,7 +2,7 @@ from loguru import logger
 
 from baldrick.plugins.github_pull_requests import pull_request_handler
 
-MISSING_MESSAGE = 'This pull request has no milestone set.'
+MISSING_MESSAGE = 'Maintainers need to set the milestone for this pull request.'
 PRESENT_MESSAGE = 'This pull request has a milestone set.'
 
 


### PR DESCRIPTION
...  to make it clear to contributors it's not an action item for them

I'm just tired of having to explain it so often. Also, maybe a rephrase for the changelog would be useful, too (e.g. wait to see whether one is required or not).