### PR TITLE
[astropy-bot] BUG: A JSON web token could not be decoded

### DIFF
--- a/baldrick/github/github_auth.py
+++ b/baldrick/github/github_auth.py
@@ -46,8 +46,8 @@ def get_json_web_token():
         payload['iss'] = int(os.environ['GITHUB_APP_INTEGRATION_ID'])
 
         json_web_token = jwt.encode(payload,
-                                    os.environ['GITHUB_APP_PRIVATE_KEY'].encode('ascii'),
-                                    algorithm='RS256').decode('ascii')
+                                    os.environ['GITHUB_APP_PRIVATE_KEY'],
+                                    algorithm='RS256')
 
     return json_web_token
 


### PR DESCRIPTION
astropy-bot keeps getting `Exception: A JSON web token could not be decoded` and the Heroku log isn't very useful. I don't even know if this is the right fix.

The log has a bunch of stuff and ends in something like this:

```
2021-03-31T14:32:18.004619+00:00 app[web.1]:   File "/app/.heroku/python/lib/python3.8/site-packages/baldrick/github/github_auth.py", line 106, in github_request_headers
2021-03-31T14:32:18.004619+00:00 app[web.1]:     token = get_installation_token(installation)
2021-03-31T14:32:18.004620+00:00 app[web.1]:             │                      └ xxxxx
2021-03-31T14:32:18.004620+00:00 app[web.1]:             └ <function get_installation_token at ...>
2021-03-31T14:32:18.004620+00:00 app[web.1]:   File "/app/.heroku/python/lib/python3.8/site-packages/baldrick/github/github_auth.py", line 94, in get_installation_token
2021-03-31T14:32:18.004621+00:00 app[web.1]:     raise Exception(resp['message'])
2021-03-31T14:32:18.004621+00:00 app[web.1]:                     └ {'message': 'A JSON web token could not be decoded', 'documentation_url': 'https://docs.github.com/rest'}
2021-03-31T14:32:18.004621+00:00 app[web.1]: 
2021-03-31T14:32:18.004622+00:00 app[web.1]: Exception: A JSON web token could not be decoded
```

@Cadair , you know what is going on? `astropy-bot` is not running at all because of this.