### PR TITLE
PR should pull config from default branch, master -> main

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 0.3 (unreleased)
 ----------------
 
+* Fix ``PullRequestHandler`` to grab configuration file from default branch
+  of upstream repository. Default branch in ``github_api`` module is now
+  ``main``, not ``master``; but this does not affect existing plugins and
+  scripts unless they fall back to ``github_api`` default. [#??]
+
 * New API to post checks on GitHub. [#45]
 
 * Remove support for ``post_pr_comment`` - instead we now support exclusively

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,11 +1,6 @@
 0.3 (unreleased)
 ----------------
 
-* Fix ``PullRequestHandler`` to grab configuration file from default branch
-  of upstream repository. Default branch in ``github_api`` module is now
-  ``main``, not ``master``; but this does not affect existing plugins and
-  scripts unless they fall back to ``github_api`` default. [#??]
-
 * New API to post checks on GitHub. [#45]
 
 * Remove support for ``post_pr_comment`` - instead we now support exclusively
@@ -25,6 +20,11 @@
 
 * Added ``check_base_branch`` plugin to make sure that a new pull request
   is opened against the correct upstream base branch (e.g., ``master``). [#92]
+
+* Fix ``PullRequestHandler`` to grab configuration file from default branch
+  of upstream repository. Default branch in ``github_api`` module is now
+  ``main``, not ``master``; but this does not affect existing plugins and
+  scripts unless they fall back to ``github_api`` default. [#112]
 
 0.2 (2018-11-22)
 ----------------

--- a/baldrick/blueprints/github.py
+++ b/baldrick/blueprints/github.py
@@ -40,7 +40,7 @@ def github_webhook():
         installation = payload['installation']['id']
 
     repo_name = payload['repository']['full_name']
-    repo = RepoHandler(repo_name, installation=installation)
+    repo = RepoHandler(repo_name, branch='main', installation=installation)
 
     for handler in GITHUB_WEBHOOK_HANDLERS:
         handler(repo, payload, request.headers)

--- a/baldrick/github/tests/test_github_api.py
+++ b/baldrick/github/tests/test_github_api.py
@@ -180,7 +180,8 @@ class TestIssueHandler:
     def test_missing_labels(self):
         with patch('baldrick.github.github_api.IssueHandler.labels', new_callable=PropertyMock) as mock_issue_labels:  # noqa
             mock_issue_labels.return_value = ['io.fits']
-            with patch('baldrick.github.github_api.RepoHandler.get_all_labels') as mock_repo_labels:  # noqa
+            with patch('baldrick.github.github_api.RepoHandler.get_all_labels') as mock_repo_labels, patch('baldrick.github.github_api.RepoHandler.default_branch',new_callable=PropertyMock) as mock_default_branch:  # noqa
+                mock_default_branch.return_value = 'main'
                 mock_repo_labels.return_value = ['io.fits', 'closed-by-bot']
 
                 # closed-by-bot label will be added to issue in POST

--- a/baldrick/plugins/github_towncrier_changelog.py
+++ b/baldrick/plugins/github_towncrier_changelog.py
@@ -4,7 +4,6 @@ from collections import OrderedDict
 from pathlib import Path
 
 from loguru import logger
-from toml import loads
 
 from .github_pull_requests import pull_request_handler
 
@@ -99,8 +98,7 @@ def verify_pr_number(pr_number, matching_file):
 
 
 def load_towncrier_config(pr_handler):
-    file_content = pr_handler.get_file_contents("pyproject.toml", branch=pr_handler.base_branch)
-    config = loads(file_content)
+    config = pr_handler.get_repo_config()
     if "towncrier" in config.get("tool", {}):
         return parse_toml(config)
 

--- a/baldrick/plugins/tests/test_github_pushes.py
+++ b/baldrick/plugins/tests/test_github_pushes.py
@@ -44,7 +44,7 @@ class TestPushHandler:
         self.get_file_contents_mock.stop()
         self.get_installation_token_mock.stop()
 
-    def send_event(self, client, git_ref='refs/heads/master'):
+    def send_event(self, client, git_ref='refs/heads/main'):
 
         data = {'ref': git_ref,
                 'repository': {'full_name': 'test-repo'},
@@ -69,7 +69,7 @@ class TestPushHandler:
         assert test_handler.call_count == 1
         repo_handler, git_ref = test_handler.call_args[0]
         assert repo_handler.repo == 'test-repo'
-        assert repo_handler.branch == 'master'
+        assert repo_handler.branch == 'main'
         assert git_ref == 'refs/tags/stable'
 
     def test_disabled(self, app, client):

--- a/template/pyproject.toml
+++ b/template/pyproject.toml
@@ -36,4 +36,4 @@
   [ tool.<your-bot-name>.basebranch_checker ]
 
     # enabled = true
-    # basebranch = "master"
+    # basebranch = "main"


### PR DESCRIPTION
Have PR pull config from upstream default branch. Fix #111 

Change default branch in github API from master to main.

# TODO

- [ ] Fix tests. I don't understand why the mock magic isn't seeing the config no more. Things seem to work when I live-test it locally without mock.
- [x] Insert PR number in change log.