### PR TITLE
Change default branch from master to main

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,10 @@
 * Added ``check_base_branch`` plugin to make sure that a new pull request
   is opened against the correct upstream base branch (e.g., ``master``). [#92]
 
+* Default branch is now ``main`` in ``github_api.py`` but this should not
+  affect existing scripts or plugins unless they fallback to that default.
+  [#114]
+
 0.2 (2018-11-22)
 ----------------
 

--- a/baldrick/github/github_api.py
+++ b/baldrick/github/github_api.py
@@ -71,7 +71,7 @@ class GitHubHandler:
     def _url_contents(self):
         return f'{HOST}/repos/{self.repo}/contents/'
 
-    def get_file_contents(self, path_to_file, branch='master'):
+    def get_file_contents(self, path_to_file, branch='main'):
         cache_key = f"{self.repo}:{path_to_file}@{branch}"
 
         # It seems that this is the only safe way to do this with
@@ -93,7 +93,7 @@ class GitHubHandler:
         FILE_CACHE[cache_key] = contents
         return contents
 
-    def get_repo_config(self, branch='master', path_to_file='pyproject.toml'):
+    def get_repo_config(self, branch='main', path_to_file='pyproject.toml'):
         """
         Load configuration from the repository.
 
@@ -101,7 +101,7 @@ class GitHubHandler:
         Parameters
         ----------
         branch : `str`
-            The branch to read the config file from. (Will default to 'master')
+            The branch to read the config file from. (Will default to 'main')
 
         path_to_file : `str`
             Path to the ``pyproject.toml`` file in the repository. Will default
@@ -113,8 +113,8 @@ class GitHubHandler:
             Configuration parameters.
 
         """
-        # Also default to 'master' if branch is None
-        branch = branch or 'master'
+        # Also default to 'main' if branch is None
+        branch = branch or 'main'
         app_config = current_app.conf.copy()
         fallback_config = Config()
         repo_config = Config()
@@ -264,7 +264,7 @@ class GitHubHandler:
 
 class RepoHandler(GitHubHandler):
 
-    def __init__(self, repo, branch='master', installation=None):
+    def __init__(self, repo, branch='main', installation=None):
         self.branch = branch
         super().__init__(repo, installation=installation)
 
@@ -462,7 +462,7 @@ class IssueHandler(GitHubHandler):
         if len(missing_labels) == 0:
             return
 
-        # Need repo handler (master branch)
+        # Need repo handler (main branch)
         if 'repohandler' not in self._cache:
             repo = RepoHandler(self.repo, installation=self.installation)
             self._cache['repohandler'] = repo

--- a/baldrick/plugins/tests/test_github_pushes.py
+++ b/baldrick/plugins/tests/test_github_pushes.py
@@ -44,7 +44,7 @@ class TestPushHandler:
         self.get_file_contents_mock.stop()
         self.get_installation_token_mock.stop()
 
-    def send_event(self, client, git_ref='refs/heads/master'):
+    def send_event(self, client, git_ref='refs/heads/main'):
 
         data = {'ref': git_ref,
                 'repository': {'full_name': 'test-repo'},
@@ -69,7 +69,7 @@ class TestPushHandler:
         assert test_handler.call_count == 1
         repo_handler, git_ref = test_handler.call_args[0]
         assert repo_handler.repo == 'test-repo'
-        assert repo_handler.branch == 'master'
+        assert repo_handler.branch == 'main'
         assert git_ref == 'refs/tags/stable'
 
     def test_disabled(self, app, client):

--- a/template/pyproject.toml
+++ b/template/pyproject.toml
@@ -36,4 +36,4 @@
   [ tool.<your-bot-name>.basebranch_checker ]
 
     # enabled = true
-    # basebranch = "master"
+    # basebranch = "main"


### PR DESCRIPTION
Change default branch from master to main for `github_api` module.

Not sure how controversial this is.